### PR TITLE
Fix external urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ jspm_packages
 !/log/.keep
 /tmp
 *.gem
+
+Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+require:
+  - rubocop-rspec
+
+Metrics/BlockLength:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false

--- a/bin/github-to-canvas
+++ b/bin/github-to-canvas
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
 
+$:.unshift File.dirname(__FILE__)
 
 require 'optparse'
-require 'github-to-canvas'
+require_relative '../lib/github-to-canvas'
 
 options = {}
 OptionParser.new do |opts|

--- a/bin/github-to-canvas
+++ b/bin/github-to-canvas
@@ -1,9 +1,10 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.dirname(__FILE__)
+lib_dir = File.expand_path(File.join(File.dirname(__FILE__), '../lib'))
+$LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
 
 require 'optparse'
-require_relative '../lib/github-to-canvas'
+require 'github-to-canvas'
 
 options = {}
 OptionParser.new do |opts|

--- a/github-to-canvas.gemspec
+++ b/github-to-canvas.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'github-to-canvas'
-  s.version = '0.1.15'
+  s.version = '0.1.16'
   s.date = '2020-05-12'
   s.authors = ['maxwellbenton']
   s.email = 'maxwell@flatironschool.com'

--- a/lib/github-to-canvas.rb
+++ b/lib/github-to-canvas.rb
@@ -23,7 +23,7 @@ class GithubToCanvas
     when 'map'
       CanvasInterface.map_course_info(options)
     when 'csv'
-      CanvasInterface.csv(options[:file_to_convert])
+      CanvasInterface.csv(options[:file_to_convert]) # not working properly
     when 'canvas_read'
       puts CanvasInterface.read_lesson(options[:filepath])
     when 'canvas_copy'

--- a/lib/github-to-canvas/canvas_interface.rb
+++ b/lib/github-to-canvas/canvas_interface.rb
@@ -217,12 +217,9 @@ class CanvasInterface
             response = RestClient.get(url, self.headers)
             lessons = JSON.parse(response.body)
             lessons = lessons.map do |lesson|
-              if lesson["type"] == "ExternalUrl"
-                next
-              end
               lesson = lesson.slice("id","title","name","indent","type","html_url","page_url","url","completion_requirement", "published")
               lesson["repository"] = ""
-              lesson['id'] = lesson['url'].gsub(/^(.*[\\\/])/,'')
+              lesson['id'] = lesson['url']&.gsub(/^(.*[\\\/])/,'')
               lesson
             end
             if ([200, 201].include? response.code) && (!lessons.empty?)
@@ -247,6 +244,7 @@ class CanvasInterface
     course_info = YAML.load(File.read("#{Dir.pwd}/#{options[:file_to_convert]}"))
     course_info[:modules] = course_info[:modules].map do |mod|
       mod[:lessons] = mod[:lessons].map do |lesson|
+        next lesson unless lesson.key?("url")
 
         url = lesson["url"]
         response = RestClient.get(url, headers={

--- a/lib/github-to-canvas/repository_converter.rb
+++ b/lib/github-to-canvas/repository_converter.rb
@@ -1,5 +1,4 @@
 require 'redcarpet'
-require 'byebug'
 class CustomRender < Redcarpet::Render::HTML
   def block_code(code, lang)
     "<pre>" \
@@ -51,7 +50,6 @@ class RepositoryConverter
   end
 
   def self.adjust_converted_html(options, html)
-    
     if options[:remove_header_and_footer]
       html = self.remove_header_and_footer(html)
     end
@@ -63,19 +61,16 @@ class RepositoryConverter
     if options[:contains_html]
       html = self.fix_escaped_inline_html_code(html)
     end
-
     html
   end
 
   def self.fix_escaped_inline_html_code(html)
     
-
     html
   end
 
-
   def self.escape_existing_html(markdown)
-    markdown = markdown.gsub(/```(\n|.)*```/) { |code|
+    markdown = markdown.gsub(/```(\n|.)*?```/) { |code|
       # all code blocks
       code = code.gsub("<", "&lt;")
       code = code.gsub(">", "&gt;")
@@ -85,7 +80,7 @@ class RepositoryConverter
 
   def self.remove_header_and_footer(html)
     new_html = self.remove_html_header(html)
-    new_html = self.remove_footer(new_html)
+    # new_html = self.remove_footer(new_html)
     new_html
   end
 
@@ -102,7 +97,7 @@ class RepositoryConverter
   end
 
   def self.remove_html_header(html)
-    html.gsub(/<h1>.*<\/h1>/,"")
+    html.gsub(/<h1>.*?<\/h1>/,"")
   end
 
   def self.fix_local_html_links(options, html, filepath)

--- a/lib/github-to-canvas/version.rb
+++ b/lib/github-to-canvas/version.rb
@@ -1,3 +1,3 @@
 class GithubToCanvas
-  VERSION = "0.1.15"
+  VERSION = "0.1.16"
 end


### PR DESCRIPTION
Fixes #5 - lessons that had the type `ExternalUrl` were being mapped as an empty object when using the `--query` option which would produce yaml with empty array elements. When that yaml was fed to the `--map` option, it would throw an error.