### PR TITLE
DS improvements

### DIFF
--- a/bin/github-to-canvas
+++ b/bin/github-to-canvas
@@ -132,6 +132,27 @@ OptionParser.new do |opts|
           "Only generate the HTML header") do
             options[:header_only] = true
           end
+  opts.on("--grading-type TYPE", 
+          "Sets the 'grading_type' for an assignment. Default: pass_fail. Valid options: pass_fail, percent, letter_grade, gpa_scale, points, not_graded") do |grading_type|
+            valid_types = %w[pass_fail percent letter_grade gpa_scale points not_graded]
+            unless valid_types.include? grading_type
+              raise "Invalid grading type: #{grading_type}"
+            end
+            options[:grading_type] = grading_type
+          end
+  opts.on("--submission-type TYPE", 
+          "Sets the 'submission_type' for an assignment. Default: online_url. Valid options: online_quiz, none, on_paper, discussion_topic, external_tool, online_upload, online_text_entry, online_url, media_recording, student_annotation") do |submission_type|
+            valid_types = %w[online_quiz none on_paper discussion_topic external_tool online_upload online_text_entry online_url media_recording student_annotation]
+            unless valid_types.include? submission_type
+              raise "Invalid grading type: #{submission_type}"
+            end
+            options[:submission_type] = submission_type
+          end
+  opts.on("--points-possible POINTS",
+          Integer,
+          "Sets the 'points_possible' for an assignment. Default: 1.") do |points_possible|
+            options[:points_possible] = points_possible
+          end
   opts.on("--course COURSE",
           "For align functionality only - updates the HTML content of a lesson using the provided course ID. Use with --id.") do |course_id|
             options[:course_id] = course_id
@@ -256,6 +277,9 @@ if options[:create_from_github]
                       course_id: options[:course_id], 
                       type: options[:type],
                       name: options[:name],
+                      grading_type: options.fetch(:grading_type, 'pass_fail'),
+                      submission_type: options.fetch(:submission_type, 'online_url'),
+                      points_possible: options.fetch(:points_possible, 1),
                       remove_header_and_footer: !!options[:remove_header_and_footer],
                       forkable: !!options[:forkable],
                       fis_links: !!options[:fis],
@@ -276,6 +300,9 @@ if options[:align_from_github]
                       type: options[:type], 
                       id: options[:id],
                       name: options[:name],
+                      grading_type: options.fetch(:grading_type, 'pass_fail'),
+                      submission_type: options.fetch(:submission_type, 'online_url'),
+                      points_possible: options.fetch(:points_possible, 1),
                       remove_header_and_footer: !!options[:remove_header_and_footer],
                       forkable: !!options[:forkable],
                       fis_links: !!options[:fis],
@@ -432,6 +459,9 @@ if options[:create_lesson]
                     branch: options[:branch], 
                     name: options[:name], 
                     type: options[:type], 
+                    grading_type: options.fetch(:grading_type, 'pass_fail'),
+                    submission_type: options.fetch(:submission_type, 'online_url'),
+                    points_possible: options.fetch(:points_possible, 1),
                     save_to_github: !!options[:save_to_github], 
                     fis_links: !!options[:fis], 
                     git_links: !!options[:git_links],
@@ -452,6 +482,9 @@ if options[:align]
                     branch: options[:branch],
                     name: options[:name],
                     type: options[:type],
+                    grading_type: options.fetch(:grading_type, 'pass_fail'),
+                    submission_type: options.fetch(:submission_type, 'online_url'),
+                    points_possible: options.fetch(:points_possible, 1),
                     save_to_github: !!options[:save_to_github], 
                     fis_links: !!options[:fis],
                     git_links: !!options[:git_links], 

--- a/bin/github-to-canvas
+++ b/bin/github-to-canvas
@@ -153,6 +153,10 @@ OptionParser.new do |opts|
           "Sets the 'points_possible' for an assignment. Default: 1.") do |points_possible|
             options[:points_possible] = points_possible
           end
+  opts.on("--illumidesk",
+          "Configure assignment to use IllumiDesk for submission") do
+            options[:illumidesk] = true
+          end
   opts.on("--course COURSE",
           "For align functionality only - updates the HTML content of a lesson using the provided course ID. Use with --id.") do |course_id|
             options[:course_id] = course_id
@@ -277,6 +281,7 @@ if options[:create_from_github]
                       course_id: options[:course_id], 
                       type: options[:type],
                       name: options[:name],
+                      illumidesk: !!options[:illumidesk],
                       grading_type: options.fetch(:grading_type, 'pass_fail'),
                       submission_type: options.fetch(:submission_type, 'online_url'),
                       points_possible: options.fetch(:points_possible, 1),
@@ -300,6 +305,7 @@ if options[:align_from_github]
                       type: options[:type], 
                       id: options[:id],
                       name: options[:name],
+                      illumidesk: !!options[:illumidesk],
                       grading_type: options.fetch(:grading_type, 'pass_fail'),
                       submission_type: options.fetch(:submission_type, 'online_url'),
                       points_possible: options.fetch(:points_possible, 1),
@@ -459,6 +465,7 @@ if options[:create_lesson]
                     branch: options[:branch], 
                     name: options[:name], 
                     type: options[:type], 
+                    illumidesk: !!options[:illumidesk],
                     grading_type: options.fetch(:grading_type, 'pass_fail'),
                     submission_type: options.fetch(:submission_type, 'online_url'),
                     points_possible: options.fetch(:points_possible, 1),
@@ -482,6 +489,7 @@ if options[:align]
                     branch: options[:branch],
                     name: options[:name],
                     type: options[:type],
+                    illumidesk: !!options[:illumidesk],
                     grading_type: options.fetch(:grading_type, 'pass_fail'),
                     submission_type: options.fetch(:submission_type, 'online_url'),
                     points_possible: options.fetch(:points_possible, 1),

--- a/bin/github-to-canvas
+++ b/bin/github-to-canvas
@@ -128,6 +128,10 @@ OptionParser.new do |opts|
           "Removes top lesson header and any Learn.co specific footer links before converting to HTML") do |r|
             options[:remove_header_and_footer] = true
           end
+  opts.on("--header-only",
+          "Only generate the HTML header") do
+            options[:header_only] = true
+          end
   opts.on("--course COURSE",
           "For align functionality only - updates the HTML content of a lesson using the provided course ID. Use with --id.") do |course_id|
             options[:course_id] = course_id
@@ -240,7 +244,8 @@ if options[:read_from_github]
                     forkable: !!options[:forkable],
                     fis_links: !!options[:fis],
                     aaq: !!options[:aaq],
-                    prework: !!options[:prework])
+                    prework: !!options[:prework],
+                    header_only: !!options[:header_only])
   abort
 end
 
@@ -255,7 +260,8 @@ if options[:create_from_github]
                       forkable: !!options[:forkable],
                       fis_links: !!options[:fis],
                       aaq: !!options[:aaq],
-                      prework: !!options[:prework])
+                      prework: !!options[:prework],
+                      header_only: !!options[:header_only])
   else
     puts 'Canvas course ID and lesson type required. Example: github-to-canvas --create-from-github URL --course ID --type TYPE'
   end
@@ -274,7 +280,8 @@ if options[:align_from_github]
                       forkable: !!options[:forkable],
                       fis_links: !!options[:fis],
                       aaq: !!options[:aaq],
-                      prework: !!options[:prework])
+                      prework: !!options[:prework],
+                      header_only: !!options[:header_only])
   else
     puts 'Canvas course ID, lesson ID, and type required. Example: github-to-canvas --create-from-github URL --course COURSE_ID --id LESSON_ID --type TYPE'
   end
@@ -308,7 +315,8 @@ if options[:csv_build]
                     aaq: !!options[:aaq],
                     forkable: !!options[:forkable],
                     branch: options[:branch],
-                    git_links: !!options[:git_links])
+                    git_links: !!options[:git_links],
+                    header_only: !!options[:header_only])
   abort
 end
 
@@ -321,7 +329,8 @@ if options[:csv_align]
                     aaq: !!options[:aaq],
                     forkable: !!options[:forkable],
                     branch: options[:branch],
-                    git_links: !!options[:git_links])
+                    git_links: !!options[:git_links],
+                    header_only: !!options[:header_only])
   abort
 end
 
@@ -333,7 +342,8 @@ if options[:build_course]
                     aaq: !!options[:aaq],
                     prework: !!options[:prework],
                     forkable: !!options[:forkable],
-                    git_links: !!options[:git_links])
+                    git_links: !!options[:git_links],
+                    header_only: !!options[:header_only])
   abort
 end
 
@@ -347,7 +357,8 @@ if options[:add_to_course]
                       forkable: !!options[:forkable],
                       aaq: !!options[:aaq],
                       prework: !!options[:prework],
-                      git_links: !!options[:git_links])
+                      git_links: !!options[:git_links],
+                      header_only: !!options[:header_only])
   else
     puts '--course required'
   end
@@ -362,7 +373,8 @@ if options[:update_course_lessons]
                     forkable: !!options[:forkable],
                     aaq: !!options[:aaq],
                     prework: !!options[:prework],
-                    git_links: !!options[:git_links])
+                    git_links: !!options[:git_links],
+                    header_only: !!options[:header_only])
   abort
 end
 
@@ -427,7 +439,8 @@ if options[:create_lesson]
                     only_update_content: !!options[:only_content],
                     forkable: !!options[:forkable],
                     aaq: !!options[:aaq],
-                    prework: !!options[:prework])
+                    prework: !!options[:prework],
+                    header_only: !!options[:header_only])
 end
 
 if options[:align]
@@ -446,5 +459,6 @@ if options[:align]
                     only_update_content: !!options[:only_content],
                     forkable: !!options[:forkable],
                     aaq: !!options[:aaq],
-                    prework: !!options[:prework])
+                    prework: !!options[:prework],
+                    header_only: !!options[:header_only])
 end

--- a/bin/github-to-canvas
+++ b/bin/github-to-canvas
@@ -128,6 +128,14 @@ OptionParser.new do |opts|
           "Removes top lesson header and any Learn.co specific footer links before converting to HTML") do |r|
             options[:remove_header_and_footer] = true
           end
+  opts.on("-d", "--ds-assignment",
+          "Configure the following options: --header-only --illumidesk --grading-type points --submission-type external_tool --points-possible 0") do
+            options[:header_only] = true
+            options[:illumidesk] = true
+            options[:grading_type] = 'points'
+            options[:submission_type] = 'external_tool'
+            options[:points_possible] = 0
+          end
   opts.on("--header-only",
           "Only generate the HTML header") do
             options[:header_only] = true
@@ -144,7 +152,7 @@ OptionParser.new do |opts|
           "Sets the 'submission_type' for an assignment. Default: online_url. Valid options: online_quiz, none, on_paper, discussion_topic, external_tool, online_upload, online_text_entry, online_url, media_recording, student_annotation") do |submission_type|
             valid_types = %w[online_quiz none on_paper discussion_topic external_tool online_upload online_text_entry online_url media_recording student_annotation]
             unless valid_types.include? submission_type
-              raise "Invalid grading type: #{submission_type}"
+              raise "Invalid submission type: #{submission_type}"
             end
             options[:submission_type] = submission_type
           end

--- a/lib/github-to-canvas/canvas_dotfile.rb
+++ b/lib/github-to-canvas/canvas_dotfile.rb
@@ -42,7 +42,10 @@ class CanvasDotfile
         id: response['id'],
         course_id: course.to_i,
         canvas_url: response['html_url'],
-        type: type
+        type: type,
+        grading_type: response['grading_type'],
+        points_possible: response['points_possible'],
+        submission_type: response['submission_types'][0],
       }  
       canvas_data[:lessons] << lesson_data
     end
@@ -56,7 +59,10 @@ class CanvasDotfile
           id: response['id'],
           course_id: course.to_i,
           canvas_url: response['html_url'],
-          type: type
+          type: type,
+          grading_type: response['grading_type'],
+          submission_type: response['submission_types'][0],
+          points_possible: response['points_possible']
         }
       ]
     }

--- a/lib/github-to-canvas/canvas_interface.rb
+++ b/lib/github-to-canvas/canvas_interface.rb
@@ -117,7 +117,9 @@ class CanvasInterface
         options[:id] = lesson[:id]
         options[:course_id] = lesson[:course_id]
         options[:type] = lesson[:type]
-        
+        options[:submission_type] = lesson.fetch(:submission_type, 'online_url')
+        options[:grading_type] = lesson.fetch(:grading_type, 'pass_fail')
+        options[:points_possible] = lesson.fetch(:points_possible, 1)
       }
       RepositoryInterface.local_repo_post_submission(options, response)
       puts "Canvas lesson updated. Lesson available at #{response['html_url']}"
@@ -389,9 +391,9 @@ class CanvasInterface
         payload = {
           'assignment[name]' => name,
           'assignment[description]' => html,
-          'assignment[submission_types][]' => "online_url",
-          'assignment[grading_type]' => 'pass_fail',
-          'assignment[points_possible]' => 1
+          'assignment[submission_types][]' => options.fetch(:submission_type, 'online_url'),
+          'assignment[grading_type]' => options.fetch(:grading_type, 'pass_fail'),
+          'assignment[points_possible]' => options.fetch(:points_possible, 1)
         }
       elsif options[:type] == "discussion"
         payload = {

--- a/lib/github-to-canvas/repository_converter.rb
+++ b/lib/github-to-canvas/repository_converter.rb
@@ -41,6 +41,8 @@ class RepositoryConverter
   end
 
   def self.adjust_converted_html(options, html)
+    return self.add_fis_links(options, "") if options[:header_only]
+
     if options[:remove_header_and_footer]
       html = self.remove_header_and_footer(html)
     end


### PR DESCRIPTION
Adds options for creating and aligning Data Science assignments, for example:

```console
$ github-to-canvas --create-from-github https://github.com/learn-co-curriculum/ian-test --course 153 --type assignment --ds-assigment
```

This will create a new assignment, and set the following options:

- `header_only`: true (Only produces HTML header in Canvas)
- `illumidesk`: true (Adds configuration for using IllumiDesk as external tool for assignment)
- `grading_type`: points
- `points_possible`: 0
- `submission_type`: external_url

Each of these options can also be configured individually by passing in the corresponding flags (run `github-to-canvas --help` for details).

**Note**: This configuration only applies to creating/updating individual lessons, and is not enabled for mass assignment creation/update features, such as `--build-course`.