### PR TITLE
Add to course local

### DIFF
--- a/bin/github-to-canvas
+++ b/bin/github-to-canvas
@@ -60,6 +60,7 @@ OptionParser.new do |opts|
 
     github-to-canvas --build-course YAML_FILE                                                     -> Uses the provided YAML file to create a course, add modules and populate them with lessons using remote GitHub repositories
     github-to-canvas --add-to-course YAML_FILE --course                                           -> Uses a YAML file to add modules and lessons to an existing course from remote (public) GitHub repository.
+    github-to-canvas --add-to-course-local YAML_FILE --course                                     -> Uses a YAML file to add modules and lessons to an existing course from local GitHub repository. Paths should be relative to the YAML file location.
     github-to-canvas --update-course YAML_FILE                                                    -> Uses a YAML file to update lessons using their associated GitHub repositories (ignores module/course structure in YAML file)
 
   EOBANNER
@@ -183,6 +184,10 @@ OptionParser.new do |opts|
   opts.on("--add-to-course YAML_FILE", 
           "Creates Canvas course using provided YAML file with URLs to remote public GitHub repository") do |file|
             options[:add_to_course] = file
+          end
+  opts.on("--add-to-course-local YAML_FILE", 
+          "Creates Canvas course using provided YAML file with relative paths to local GitHub repository") do |file|
+            options[:add_to_course_local] = file
           end
   opts.on("--update-course-lessons YAML_FILE", 
           "Updates all lessons in a course using remote repos in provided YAML file") do |file|
@@ -342,6 +347,23 @@ if options[:add_to_course]
     GithubToCanvas.new(mode: 'add_to_course', 
                       course_id: options[:course_id], 
                       file_to_convert: options[:add_to_course],
+                      fis_links: !!options[:fis], 
+                      remove_header_and_footer: !!options[:remove_header_and_footer],
+                      forkable: !!options[:forkable],
+                      aaq: !!options[:aaq],
+                      prework: !!options[:prework],
+                      git_links: !!options[:git_links])
+  else
+    puts '--course required'
+  end
+  abort
+end
+
+if options[:add_to_course_local]
+  if options[:course_id]
+    GithubToCanvas.new(mode: 'add_to_course_local', 
+                      course_id: options[:course_id], 
+                      yaml_file_to_convert: options[:add_to_course_local], # distinguish from file_to_convert which will come from repository values in YAML
                       fis_links: !!options[:fis], 
                       remove_header_and_footer: !!options[:remove_header_and_footer],
                       forkable: !!options[:forkable],

--- a/bin/github-to-canvas
+++ b/bin/github-to-canvas
@@ -62,6 +62,7 @@ OptionParser.new do |opts|
     github-to-canvas --add-to-course YAML_FILE --course                                           -> Uses a YAML file to add modules and lessons to an existing course from remote (public) GitHub repository.
     github-to-canvas --add-to-course-local YAML_FILE --course                                     -> Uses a YAML file to add modules and lessons to an existing course from local GitHub repository. Paths should be relative to the YAML file location.
     github-to-canvas --update-course YAML_FILE                                                    -> Uses a YAML file to update lessons using their associated remote (public) GitHub repositories (ignores module/course structure in YAML file)
+    github-to-canvas --update-course-local YAML_FILE                                              -> Uses a YAML file to update lessons using their associated local paths to GitHub repositories (ignores module/course structure in YAML file)
 
   EOBANNER
 
@@ -192,6 +193,10 @@ OptionParser.new do |opts|
   opts.on("--update-course-lessons YAML_FILE", 
           "Updates all lessons in a course using remote (public) repos in provided YAML file") do |file|
             options[:update_course_lessons] = file
+          end
+  opts.on("--update-course-lessons-local YAML_FILE", 
+          "Updates all lessons in a course using local repo paths in provided YAML file") do |file|
+            options[:update_course_lessons_local] = file
           end
   opts.on("--clone-from-yaml YAML_FILE", 
           "Iterates over provided course YAML file and clones repos locally") do |file|
@@ -379,6 +384,18 @@ end
 if options[:update_course_lessons]
   GithubToCanvas.new(mode: 'update_course_lessons', 
                     file_to_convert: options[:update_course_lessons],
+                    fis_links: !!options[:fis], 
+                    remove_header_and_footer: !!options[:remove_header_and_footer],
+                    forkable: !!options[:forkable],
+                    aaq: !!options[:aaq],
+                    prework: !!options[:prework],
+                    git_links: !!options[:git_links])
+  abort
+end
+
+if options[:update_course_lessons_local]
+  GithubToCanvas.new(mode: 'update_course_lessons_local', 
+                    yaml_file_to_convert: options[:update_course_lessons_local],
                     fis_links: !!options[:fis], 
                     remove_header_and_footer: !!options[:remove_header_and_footer],
                     forkable: !!options[:forkable],

--- a/bin/github-to-canvas
+++ b/bin/github-to-canvas
@@ -61,7 +61,7 @@ OptionParser.new do |opts|
     github-to-canvas --build-course YAML_FILE                                                     -> Uses the provided YAML file to create a course, add modules and populate them with lessons using remote GitHub repositories
     github-to-canvas --add-to-course YAML_FILE --course                                           -> Uses a YAML file to add modules and lessons to an existing course from remote (public) GitHub repository.
     github-to-canvas --add-to-course-local YAML_FILE --course                                     -> Uses a YAML file to add modules and lessons to an existing course from local GitHub repository. Paths should be relative to the YAML file location.
-    github-to-canvas --update-course YAML_FILE                                                    -> Uses a YAML file to update lessons using their associated GitHub repositories (ignores module/course structure in YAML file)
+    github-to-canvas --update-course YAML_FILE                                                    -> Uses a YAML file to update lessons using their associated remote (public) GitHub repositories (ignores module/course structure in YAML file)
 
   EOBANNER
 
@@ -190,7 +190,7 @@ OptionParser.new do |opts|
             options[:add_to_course_local] = file
           end
   opts.on("--update-course-lessons YAML_FILE", 
-          "Updates all lessons in a course using remote repos in provided YAML file") do |file|
+          "Updates all lessons in a course using remote (public) repos in provided YAML file") do |file|
             options[:update_course_lessons] = file
           end
   opts.on("--clone-from-yaml YAML_FILE", 

--- a/bin/github-to-canvas
+++ b/bin/github-to-canvas
@@ -59,7 +59,7 @@ OptionParser.new do |opts|
     Create and Update Canvas Courses From YAML:
 
     github-to-canvas --build-course YAML_FILE                                                     -> Uses the provided YAML file to create a course, add modules and populate them with lessons using remote GitHub repositories
-    github-to-canvas --add-to-course YAML_FILE --course                                           -> Uses a YAML file to a modules and lessons to an existing course.
+    github-to-canvas --add-to-course YAML_FILE --course                                           -> Uses a YAML file to add modules and lessons to an existing course from remote (public) GitHub repository.
     github-to-canvas --update-course YAML_FILE                                                    -> Uses a YAML file to update lessons using their associated GitHub repositories (ignores module/course structure in YAML file)
 
   EOBANNER
@@ -181,7 +181,7 @@ OptionParser.new do |opts|
             options[:build_course] = file
           end
   opts.on("--add-to-course YAML_FILE", 
-          "Creates Canvas course using provided YAML file") do |file|
+          "Creates Canvas course using provided YAML file with URLs to remote public GitHub repository") do |file|
             options[:add_to_course] = file
           end
   opts.on("--update-course-lessons YAML_FILE", 

--- a/lib/github-to-canvas.rb
+++ b/lib/github-to-canvas.rb
@@ -133,7 +133,7 @@ class GithubToCanvas
           # split relative path from repository tag in YAML into path and file to match downstream processing expectations
           options[:filepath] = File.dirname(lesson["repository"])
           options[:file_to_convert] = File.basename(lesson["repository"])
-          html = RepositoryConverter.remote_file_conversion(options)
+          html = RepositoryConverter.local_file_conversion(options)
           # Add each lesson to it's module
           html = RepositoryConverter.adjust_converted_html(options, html)
           created_lesson_info = CanvasInterface.create_lesson(options, lesson["title"], html)


### PR DESCRIPTION
1) Updated documentation it bin/github-to-canvas to clarify the need for a remote public repository for --add-to-canvas option.
2) Added a new option (--add-to-canvas-local) that replicates the add-to-canvas functionality but will use paths to a local GitHub repository stored in the YAML file. This avoids the need of storing the GitHub materials in a public repository. Includes small additions to the bin/github-to-canvas and lib/github-to-canvas.rb files (all immediately following the existing --add-to-canvas option for simplicity).